### PR TITLE
fixed bad method call

### DIFF
--- a/providers/pear.rb
+++ b/providers/pear.rb
@@ -166,7 +166,7 @@ def remove_package(name, version)
   command << " #{prefix_channel(can_haz(@new_resource, "channel"))}#{name}"
   command << "-#{version}" if version && !version.empty?
   pear_shell_out(command)
-  manage_pecl_ini(name, :delete) if pecl?
+  manage_pecl_ini(name, :delete, {}, {}) if pecl?
 end
 
 def pear_shell_out(command)


### PR DESCRIPTION
This prevents the following error when removing a PECL package:

    wrong number of arguments (2 for 4)
