### PR TITLE
Fix to install old version of PHP from source code

### DIFF
--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -40,7 +40,11 @@ end
 version = node['php']['version']
 
 remote_file "#{Chef::Config[:file_cache_path]}/php-#{version}.tar.gz" do
-  source "#{node['php']['url']}/php-#{version}.tar.gz/from/this/mirror"
+  if %r{^http://museum.php.net/} =~ node['php']['url']
+    source "#{node['php']['url']}/php-#{version}.tar.gz"
+  else
+    source "#{node['php']['url']}/php-#{version}.tar.gz/from/this/mirror"
+  end
   checksum node['php']['checksum']
   mode '0644'
   not_if "which #{node['php']['bin']}"


### PR DESCRIPTION
I want install old PHP 5.3.6 to have verification environment.
I need this patch to download tarball from php.net.

url|result|status
---|---|---
http://www.php.net/get/php-5.5.13.tar.gz/from/a/mirror|Downloadable|Stable release
http://www.php.net/get/php-5.3.6.tar.gz/from/a/mirror|Download not found|Archived release
http://museum.php.net/php5/php-5.3.6.tar.gz|Downloadable|Archived release

## attributes

```
    chef.json = {
      :php => {
        :install_method => 'source',
        :url => 'http://museum.php.net/php5',
        :version => '5.3.6',
      }
    }
```

I tried with vagrant. I set attributes in Vagrantfile like above.