### PR TITLE
Add libapache2-mod-php5 for Ubuntu server deployent

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -44,7 +44,7 @@ when 'debian'
   default['php']['ext_conf_dir']  = '/etc/php5/conf.d'
   default['php']['fpm_user']      = 'www-data'
   default['php']['fpm_group']     = 'www-data'
-  default['php']['packages']      = %w{ php5-cgi php5 php5-dev php5-cli php-pear }
+  default['php']['packages']      = %w{ php5-cgi php5 php5-dev php5-cli php-pear libapache2-mod-php5}
 when 'suse'
   default['php']['conf_dir']      = '/etc/php5/cli'
   default['php']['ext_conf_dir']  = '/etc/php5/conf.d'


### PR DESCRIPTION
Package is required by ubuntu to display php files