### PR TITLE
correct service name on fpm pool template

### DIFF
--- a/providers/fpm_pool.rb
+++ b/providers/fpm_pool.rb
@@ -64,7 +64,7 @@ action :install do
       :fpm_pool_listen => new_resource.listen,
       :fpm_pool_manager => new_resource.process_manager,
       :fpm_pool_max_children => new_resource.max_children,
-      :fpm_pool_start_servres => new_resource.start_servers,
+      :fpm_pool_start_servers => new_resource.start_servers,
       :fpm_pool_min_spare_servers => new_resource.min_spare_servers,
       :fpm_pool_max_spare_servers => new_resource.max_spare_servers,
       :fpm_pool_chdir => new_resource.chdir,

--- a/providers/fpm_pool.rb
+++ b/providers/fpm_pool.rb
@@ -70,7 +70,7 @@ action :install do
       :fpm_pool_chdir => new_resource.chdir,
       :fpm_pool_additional_config => new_resource.additional_config
     })
-    notifies :restart, "service[#{node['php']['fpm_package']}]"
+    notifies :restart, "service[#{node['php']['fpm_service']}]"
   end
   new_resource.updated_by_last_action(t.updated_by_last_action?)
 end


### PR DESCRIPTION
Installing a php_fpm_pool resource fails if the php-fpm package name is different from the service name.