### PR TITLE
add compatibility to fpm service for Ubuntu 14.04

### DIFF
--- a/providers/fpm_pool.rb
+++ b/providers/fpm_pool.rb
@@ -43,6 +43,12 @@ end
 
 def register_fpm_service
   service node['php']['fpm_service'] do
+    case node["platform"]
+    when "ubuntu"
+      if node["platform_version"].to_f >= 14.04
+        provider Chef::Provider::Service::Upstart
+      end
+    end
     action :enable
   end
 end


### PR DESCRIPTION
Due to an issue with Ubuntu 14.04[[1]](https://www.chef.io/blog/2014/09/18/chef-where-is-my-ubuntu-14-04-service-support/) which comes with 2 init systems(SysV &
Upstart), Chef versions <11.14 [[2]](https://github.com/chef/chef/pull/1412) cannot handle the service files properly.
Added a case in the service registration to fix the issue and keep
compatibility with older Chef versions in Ubuntu 14.04.