### PR TITLE
Add ability to specify different listen.owner / listen.group from pool's user and group

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -29,25 +29,29 @@ default['php']['pecl'] = 'pecl'
 case node['platform_family']
 when 'rhel', 'fedora'
   lib_dir = node['kernel']['machine'] =~ /x86_64/ ? 'lib64' : 'lib'
-  default['php']['conf_dir']      = '/etc'
-  default['php']['ext_conf_dir']  = '/etc/php.d'
-  default['php']['fpm_user']      = 'nobody'
-  default['php']['fpm_group']     = 'nobody'
-  default['php']['ext_dir']       = "/usr/#{lib_dir}/php/modules"
-  default['php']['src_deps']      = %w(bzip2-devel libc-client-devel curl-devel freetype-devel gmp-devel libjpeg-devel krb5-devel libmcrypt-devel libpng-devel openssl-devel t1lib-devel mhash-devel)
+  default['php']['conf_dir']          = '/etc'
+  default['php']['ext_conf_dir']      = '/etc/php.d'
+  default['php']['fpm_user']          = 'nobody'
+  default['php']['fpm_group']         = 'nobody'
+  default['php']['fpm_listen_user']   = 'nobody'
+  default['php']['fpm_listen_group']  = 'nobody'
+  default['php']['ext_dir']           = "/usr/#{lib_dir}/php/modules"
+  default['php']['src_deps']          = %w(bzip2-devel libc-client-devel curl-devel freetype-devel gmp-devel libjpeg-devel krb5-devel libmcrypt-devel libpng-devel openssl-devel t1lib-devel mhash-devel)
   if node['platform_version'].to_f < 6
     default['php']['packages'] = %w(php53 php53-devel php53-cli php-pear)
     default['php']['mysql']['package'] = 'php53-mysql'
   else
     default['php']['packages'] = %w(php php-devel php-cli php-pear)
-    default['php']['mysql']['package'] = 'php-mysql'
-    default['php']['fpm_package']   = 'php-fpm'
-    default['php']['fpm_pooldir']   = '/etc/php-fpm.d'
-    default['php']['fpm_default_conf'] = '/etc/php-fpm.d/www.conf'
-    default['php']['fpm_service'] = 'php-fpm'
+    default['php']['mysql']['package']  = 'php-mysql'
+    default['php']['fpm_package']       = 'php-fpm'
+    default['php']['fpm_pooldir']       = '/etc/php-fpm.d'
+    default['php']['fpm_default_conf']  = '/etc/php-fpm.d/www.conf'
+    default['php']['fpm_service']       = 'php-fpm'
     if node['php']['install_method'] == 'package'
-      default['php']['fpm_user']      = 'apache'
-      default['php']['fpm_group']     = 'apache'
+      default['php']['fpm_user']        = 'apache'
+      default['php']['fpm_group']       = 'apache'
+      default['php']['fpm_listen_user'] = 'apache'
+      default['php']['fpm_listen_group']= 'apache'
     end
   end
 when 'debian'
@@ -62,22 +66,26 @@ when 'debian'
   else
     default['php']['ext_conf_dir'] = '/etc/php5/conf.d'
   end
-  default['php']['src_deps']      = %w(libbz2-dev libc-client2007e-dev libcurl4-gnutls-dev libfreetype6-dev libgmp3-dev libjpeg62-dev libkrb5-dev libmcrypt-dev libpng12-dev libssl-dev libt1-dev)
-  default['php']['packages']      = %w(php5-cgi php5 php5-dev php5-cli php-pear)
+  default['php']['src_deps']        = %w(libbz2-dev libc-client2007e-dev libcurl4-gnutls-dev libfreetype6-dev libgmp3-dev libjpeg62-dev libkrb5-dev libmcrypt-dev libpng12-dev libssl-dev libt1-dev)
+  default['php']['packages']        = %w(php5-cgi php5 php5-dev php5-cli php-pear)
   default['php']['mysql']['package'] = 'php5-mysql'
-  default['php']['fpm_package']   = 'php5-fpm'
-  default['php']['fpm_pooldir']   = '/etc/php5/fpm/pool.d'
-  default['php']['fpm_user']      = 'www-data'
-  default['php']['fpm_group']     = 'www-data'
-  default['php']['fpm_service']   = 'php5-fpm'
+  default['php']['fpm_package']     = 'php5-fpm'
+  default['php']['fpm_pooldir']     = '/etc/php5/fpm/pool.d'
+  default['php']['fpm_user']        = 'www-data'
+  default['php']['fpm_group']       = 'www-data'
+  default['php']['fpm_listen_user'] = 'www-data'
+  default['php']['fpm_listen_group']= 'www-data'
+  default['php']['fpm_service']     = 'php5-fpm'
   default['php']['fpm_default_conf'] = '/etc/php5/fpm/pool.d/www.conf'
 when 'suse'
-  default['php']['conf_dir']      = '/etc/php5/cli'
-  default['php']['ext_conf_dir']  = '/etc/php5/conf.d'
-  default['php']['src_deps']      = %w(libbz2-dev libc-client2007e-dev libcurl4-gnutls-dev libfreetype6-dev libgmp3-dev libjpeg62-dev libkrb5-dev libmcrypt-dev libpng12-dev libssl-dev libt1-dev)
-  default['php']['fpm_user']      = 'wwwrun'
-  default['php']['fpm_group']     = 'www'
-  default['php']['packages']      = %w(apache2-mod_php5 php5-pear)
+  default['php']['conf_dir']        = '/etc/php5/cli'
+  default['php']['ext_conf_dir']    = '/etc/php5/conf.d'
+  default['php']['src_deps']        = %w(libbz2-dev libc-client2007e-dev libcurl4-gnutls-dev libfreetype6-dev libgmp3-dev libjpeg62-dev libkrb5-dev libmcrypt-dev libpng12-dev libssl-dev libt1-dev)
+  default['php']['fpm_user']        = 'wwwrun'
+  default['php']['fpm_group']       = 'www'
+  default['php']['fpm_listen_user'] = 'wwwrun'
+  default['php']['fpm_listen_group']= 'www'
+  default['php']['packages']        = %w(apache2-mod_php5 php5-pear)
   default['php']['mysql']['package'] = 'php5-mysql'
   lib_dir = node['kernel']['machine'] =~ /x86_64/ ? 'lib64' : 'lib'
 when 'windows'
@@ -100,20 +108,24 @@ when 'windows'
   default['php']['pear']          = 'pear.bat'
   default['php']['pecl']          = 'pecl.bat'
 when 'freebsd'
-  default['php']['conf_dir']      = '/usr/local/etc'
-  default['php']['ext_conf_dir']  = '/usr/local/etc/php'
-  default['php']['src_deps']      = %w(libbz2-dev libc-client2007e-dev libcurl4-gnutls-dev libfreetype6-dev libgmp3-dev libjpeg62-dev libkrb5-dev libmcrypt-dev libpng12-dev libssl-dev libt1-dev)
-  default['php']['fpm_user']      = 'www'
-  default['php']['fpm_group']     = 'www'
-  default['php']['packages']      = %w( php56 pear )
+  default['php']['conf_dir']        = '/usr/local/etc'
+  default['php']['ext_conf_dir']    = '/usr/local/etc/php'
+  default['php']['src_deps']        = %w(libbz2-dev libc-client2007e-dev libcurl4-gnutls-dev libfreetype6-dev libgmp3-dev libjpeg62-dev libkrb5-dev libmcrypt-dev libpng12-dev libssl-dev libt1-dev)
+  default['php']['fpm_user']        = 'www'
+  default['php']['fpm_group']       = 'www'
+  default['php']['fpm_listen_user'] = 'www'
+  default['php']['fpm_listen_group']= 'www'
+  default['php']['packages']        = %w( php56 pear )
   default['php']['mysql']['package'] = 'php56-mysqli'
 else
-  default['php']['conf_dir']      = '/etc/php5/cli'
-  default['php']['ext_conf_dir']  = '/etc/php5/conf.d'
-  default['php']['src_deps']      = %w(libbz2-dev libc-client2007e-dev libcurl4-gnutls-dev libfreetype6-dev libgmp3-dev libjpeg62-dev libkrb5-dev libmcrypt-dev libpng12-dev libssl-dev libt1-dev)
-  default['php']['fpm_user']      = 'www-data'
-  default['php']['fpm_group']     = 'www-data'
-  default['php']['packages']      = %w(php5-cgi php5 php5-dev php5-cli php-pear)
+  default['php']['conf_dir']        = '/etc/php5/cli'
+  default['php']['ext_conf_dir']    = '/etc/php5/conf.d'
+  default['php']['src_deps']        = %w(libbz2-dev libc-client2007e-dev libcurl4-gnutls-dev libfreetype6-dev libgmp3-dev libjpeg62-dev libkrb5-dev libmcrypt-dev libpng12-dev libssl-dev libt1-dev)
+  default['php']['fpm_user']        = 'www-data'
+  default['php']['fpm_group']       = 'www-data'
+  default['php']['fpm_listen_user'] = 'www-data'
+  default['php']['fpm_listen_group']= 'www-data'
+  default['php']['packages']        = %w(php5-cgi php5 php5-dev php5-cli php-pear)
   default['php']['mysql']['package'] = 'php5-mysql'
 end
 

--- a/providers/fpm_pool.rb
+++ b/providers/fpm_pool.rb
@@ -62,6 +62,8 @@ action :install do
       fpm_pool_user: new_resource.user,
       fpm_pool_group: new_resource.group,
       fpm_pool_listen: new_resource.listen,
+      fpm_pool_listen_user: new_resource.listen_user,
+      fpm_pool_listen_group: new_resource.listen_group,
       fpm_pool_manager: new_resource.process_manager,
       fpm_pool_max_children: new_resource.max_children,
       fpm_pool_start_servers: new_resource.start_servers,

--- a/resources/fpm_pool.rb
+++ b/resources/fpm_pool.rb
@@ -24,7 +24,9 @@ actions :install, :uninstall
 attribute :pool_name, kind_of: String, name_attribute: true
 attribute :listen, default: '/var/run/php5-fpm.sock'
 attribute :user, kind_of: String, default: node['php']['fpm_user']
-attribute :group, kind_of: String, default: node['php']['fpm_user']
+attribute :group, kind_of: String, default: node['php']['fpm_group']
+attribute :listen_user, kind_of: String, default: node['php']['fpm_listen_user']
+attribute :listen_group, kind_of: String, default: node['php']['fpm_listen_group']
 attribute :process_manager, kind_of: String, default: 'dynamic'
 attribute :max_children, kind_of: Integer, default: 5
 attribute :start_servers, kind_of: Integer, default: 2

--- a/templates/default/fpm-pool.conf.erb
+++ b/templates/default/fpm-pool.conf.erb
@@ -2,8 +2,8 @@
 user = <%= @fpm_pool_user %>
 group = <%= @fpm_pool_group %>
 listen = <%= @fpm_pool_listen %>
-listen.owner = <%= @fpm_pool_user %>
-listen.group = <%= @fpm_pool_group %>
+listen.owner = <%= @fpm_pool_listen_user %>
+listen.group = <%= @fpm_pool_listen_group %>
 pm = <%= @fpm_pool_manager %>
 pm.max_children = <%= @fpm_pool_max_children %>
 pm.start_servers = <%= @fpm_pool_start_servers %>


### PR DESCRIPTION
Add ability to specify different listen.owner / listen.group from pool's user and group
Added all defaults to be absolutely compatible to the last available version.
These new options allow for a more secure setup where web server may be running by a different user to prevent unauthorized file manipulation...

Also noticed that there was a type in one of the files, where value of USER was being assigned instead of GROUP where GROUP was expected.

This commit is absolutely backwards compatible, although I didn't have an ability to test it, edited all files directly on github.com

Please accept this merge request, I can't deploy new servers without these changes. Thank you.