### PR TITLE
FPM fix - prevent user specified pool of www from being deleted

### DIFF
--- a/providers/fpm_pool.rb
+++ b/providers/fpm_pool.rb
@@ -36,7 +36,7 @@ def install_fpm_package
     end
     package node['php']['fpm_package'] do
       action :install
-      notifies :delete, "file[#{node['php']['fpm_default_conf']}]"
+      notifies :delete, "file[#{node['php']['fpm_default_conf']}]", :immediately
     end
   end
 end


### PR DESCRIPTION
Includes a fix to prevent a user specified pool name with the same name as the default, `www`, from being deleted on first install.

Without this fix, a user supplied `www` pool will be created and then deleted at the end of the first Chef run.