### PR TITLE
Drop pear and pecl support for php7

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -21,13 +21,16 @@
 
 include_recipe "php::#{node['php']['install_method']}"
 
-# update the main channels
-php_pear_channel 'pear.php.net' do
-  action :update
-end
+# pear does not have php7 support yet
+if node['php']['version'] < '7'
+  # update the main channels
+  php_pear_channel 'pear.php.net' do
+    action :update
+  end
 
-php_pear_channel 'pecl.php.net' do
-  action :update
+  php_pear_channel 'pecl.php.net' do
+    action :update
+  end
 end
 
 include_recipe 'php::ini'


### PR DESCRIPTION
Disables pear and pecl support for php7.

This merge assumes that you have setup a ppa and not installing php7 from source.

Allows installing php7 in a setup as follows:
Recipe:
```ruby
apt_repository 'ondrej-php' do
  uri          'ppa:ondrej/php'
  distribution node['lsb']['codename']
  only_if { node['php']['version'] >= '7' }
end
...
include_recipe 'php'
```

Role configuration:
```json
"override_attributes": {
        "php": {
            "version": "7.0",
            "conf_dir": "/etc/php/7.0/cli",
            "packages": [
                "php7.0-cgi",
                "php7.0",
                "php7.0-dev",
                "php7.0-cli",
                "php7.0-json",
                "php7.0-curl",
                "php-pear"
            ],
            "mysql": {
                "package": "php7.0-mysql"
            },
            "fpm_package": "php7.0-fpm",
            "fpm_pooldir": "/etc/php/7.0/fpm/pool.d",
            "fpm_service": "php7.0-fpm",
            "fpm_default_conf": "/etc/php/7.0/fpm/pool.d/www.conf"
        }
    }
```