### PR TITLE
PHP7 / Ubuntu 16.04 & PHP-FPM Pool Listen User/Group

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -63,11 +63,11 @@ when 'rhel', 'fedora'
       default['php']['fpm_listen_user'] = 'apache'
       default['php']['fpm_listen_group'] = 'apache'
     end
-    if node['platform'] == 'amazon' # amazon names their packages with versions
-      default['php']['packages'] = %w(php56 php56-devel php-pear)
-    else # redhat does not name their packages with version on RHEL 6+
-      default['php']['packages'] = %w(php php-devel php-pear)
-    end
+    default['php']['packages'] = if node['platform'] == 'amazon' # amazon names their packages with versions
+                                   %w(php56 php56-devel php-pear)
+                                 else # redhat does not name their packages with version on RHEL 6+
+                                   %w(php php-devel php-pear)
+                                 end
   end
 when 'debian'
   default['php']['conf_dir'] = '/etc/php5/cli'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -25,6 +25,17 @@ default['php']['bin'] = 'php'
 default['php']['pear'] = 'pear'
 default['php']['pecl'] = 'pecl'
 
+default['php']['version'] = '5.6.13'
+
+default['php']['url'] = 'http://us1.php.net/get'
+default['php']['checksum'] = '92acc6c067f5e015a6881b4119eafec10eca11722e810f2c2083f72e17119bcf'
+default['php']['prefix_dir'] = '/usr/local'
+default['php']['enable_mod'] = '/usr/sbin/php5enmod'
+default['php']['disable_mod'] = '/usr/sbin/php5dismod'
+
+default['php']['ini']['template'] = 'php.ini.erb'
+default['php']['ini']['cookbook'] = 'php'
+
 case node['platform_family']
 when 'rhel', 'fedora'
   lib_dir = node['kernel']['machine'] =~ /x86_64/ ? 'lib64' : 'lib'
@@ -38,6 +49,7 @@ when 'rhel', 'fedora'
     default['php']['packages'] = %w(php53 php53-devel php53-cli php-pear)
     default['php']['mysql']['package'] = 'php53-mysql'
   else # set fpm attributes as we're on a modern PHP release
+    default['php']['packages'] = %w(php php-devel php-cli php-pear)
     default['php']['mysql']['package'] = 'php-mysql'
     default['php']['fpm_package']   = 'php-fpm'
     default['php']['fpm_pooldir']   = '/etc/php-fpm.d'
@@ -55,16 +67,7 @@ when 'rhel', 'fedora'
   end
 when 'debian'
   default['php']['conf_dir'] = '/etc/php5/cli'
-  default['php']['ext_conf_dir'] = case node['platform']
-                                   when 'ubuntu'
-                                     if node['platform_version'].to_f >= 12.10
-                                       '/etc/php5/mods-available'
-                                     else
-                                       '/etc/php5/conf.d'
-                                     end
-                                   else
-                                     '/etc/php5/conf.d'
-                                   end
+  default['php']['ext_conf_dir']  = '/etc/php5/conf.d'
   default['php']['src_deps']      = %w(libbz2-dev libc-client2007e-dev libcurl4-gnutls-dev libfreetype6-dev libgmp3-dev libjpeg62-dev libkrb5-dev libmcrypt-dev libpng12-dev libssl-dev libt1-dev)
   default['php']['packages']      = %w(php5-cgi php5 php5-dev php5-cli php-pear)
   default['php']['mysql']['package'] = 'php5-mysql'
@@ -74,6 +77,28 @@ when 'debian'
   default['php']['fpm_group']     = 'www-data'
   default['php']['fpm_service']   = 'php5-fpm'
   default['php']['fpm_default_conf'] = '/etc/php5/fpm/pool.d/www.conf'
+  case node['platform']
+  when 'ubuntu'
+    case node['platform_version'].to_f
+    when 16.04
+      default['php']['version']          = '7.0.4'
+      default['php']['conf_dir']         = '/etc/php/7.0/cli'
+      default['php']['src_deps']         = %w(libbz2-dev libc-client2007e-dev libcurl4-gnutls-dev libfreetype6-dev libgmp3-dev libjpeg62-dev libkrb5-dev libmcrypt-dev libpng12-dev libssl-dev libt1-dev)
+      default['php']['packages']         = %w(php7.0-cgi php7.0 php7.0-dev php7.0-cli php-pear)
+      default['php']['mysql']['package'] = 'php7.0-mysql'
+      default['php']['fpm_package']      = 'php7.0-fpm'
+      default['php']['fpm_pooldir']      = '/etc/php/7.0/fpm/pool.d'
+      default['php']['fpm_service']      = 'php-fpm'
+      default['php']['fpm_default_conf'] = '/etc/php/7.0/fpm/pool.d/www.conf'
+      default['php']['enable_mod']       = '/usr/sbin/phpenmod'
+      default['php']['disable_mod']      = '/usr/sbin/phpdismod'
+      default['php']['ext_conf_dir']     = '/etc/php/7.0/mods-available'
+    when 13.04..15.10
+      default['php']['ext_conf_dir'] = '/etc/php5/mods-available'
+    when 10.04..12.10
+      default['php']['ext_conf_dir'] = '/etc/php5/conf.d'
+    end
+  end
 when 'suse'
   default['php']['conf_dir']      = '/etc/php5/cli'
   default['php']['ext_conf_dir']  = '/etc/php5/conf.d'
@@ -120,11 +145,6 @@ else
   default['php']['mysql']['package'] = 'php5-mysql'
 end
 
-default['php']['url'] = 'http://us1.php.net/get'
-default['php']['version'] = '5.6.13'
-default['php']['checksum'] = '92acc6c067f5e015a6881b4119eafec10eca11722e810f2c2083f72e17119bcf'
-default['php']['prefix_dir'] = '/usr/local'
-
 default['php']['configure_options'] = %W(--prefix=#{php['prefix_dir']}
                                          --with-libdir=#{lib_dir}
                                          --with-config-file-path=#{php['conf_dir']}
@@ -162,6 +182,3 @@ default['php']['configure_options'] = %W(--prefix=#{php['prefix_dir']}
                                          --with-sqlite3
                                          --with-pdo-mysql
                                          --with-pdo-sqlite)
-
-default['php']['ini']['template'] = 'php.ini.erb'
-default['php']['ini']['cookbook'] = 'php'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -88,13 +88,14 @@ when 'debian'
     case node['platform_version'].to_f
     when 16.04
       default['php']['version']          = '7.0.4'
+      default['php']['checksum']         = 'f6cdac2fd37da0ac0bbcee0187d74b3719c2f83973dfe883d5cde81c356fe0a8'
       default['php']['conf_dir']         = '/etc/php/7.0/cli'
-      default['php']['src_deps']         = %w(libbz2-dev libc-client2007e-dev libcurl4-gnutls-dev libfreetype6-dev libgmp3-dev libjpeg62-dev libkrb5-dev libmcrypt-dev libpng12-dev libssl-dev libt1-dev)
+      default['php']['src_deps']         = %w(libbz2-dev libc-client2007e-dev libcurl4-gnutls-dev libfreetype6-dev libgmp3-dev libjpeg62-dev libkrb5-dev libmcrypt-dev libpng12-dev libssl-dev pkg-config)
       default['php']['packages']         = %w(php7.0-cgi php7.0 php7.0-dev php7.0-cli php-pear)
       default['php']['mysql']['package'] = 'php7.0-mysql'
       default['php']['fpm_package']      = 'php7.0-fpm'
       default['php']['fpm_pooldir']      = '/etc/php/7.0/fpm/pool.d'
-      default['php']['fpm_service']      = 'php-fpm'
+      default['php']['fpm_service']      = 'php7.0-fpm'
       default['php']['fpm_default_conf'] = '/etc/php/7.0/fpm/pool.d/www.conf'
       default['php']['enable_mod']       = '/usr/sbin/phpenmod'
       default['php']['disable_mod']      = '/usr/sbin/phpdismod'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -43,6 +43,8 @@ when 'rhel', 'fedora'
   default['php']['ext_conf_dir']  = '/etc/php.d'
   default['php']['fpm_user']      = 'nobody'
   default['php']['fpm_group']     = 'nobody'
+  default['php']['fpm_listen_user']   = 'nobody'
+  default['php']['fpm_listen_group']  = 'nobody'
   default['php']['ext_dir']       = "/usr/#{lib_dir}/php/modules"
   default['php']['src_deps']      = %w(bzip2-devel libc-client-devel curl-devel freetype-devel gmp-devel libjpeg-devel krb5-devel libmcrypt-devel libpng-devel openssl-devel t1lib-devel mhash-devel)
   if node['platform_version'].to_f < 6
@@ -58,6 +60,8 @@ when 'rhel', 'fedora'
     if node['php']['install_method'] == 'package'
       default['php']['fpm_user']      = 'apache'
       default['php']['fpm_group']     = 'apache'
+      default['php']['fpm_listen_user'] = 'apache'
+      default['php']['fpm_listen_group'] = 'apache'
     end
     if node['platform'] == 'amazon' # amazon names their packages with versions
       default['php']['packages'] = %w(php56 php56-devel php-pear)
@@ -75,7 +79,9 @@ when 'debian'
   default['php']['fpm_pooldir']   = '/etc/php5/fpm/pool.d'
   default['php']['fpm_user']      = 'www-data'
   default['php']['fpm_group']     = 'www-data'
-  default['php']['fpm_service']   = 'php5-fpm'
+  default['php']['fpm_listen_user']  = 'www-data'
+  default['php']['fpm_listen_group'] = 'www-data'
+  default['php']['fpm_service']      = 'php5-fpm'
   default['php']['fpm_default_conf'] = '/etc/php5/fpm/pool.d/www.conf'
   case node['platform']
   when 'ubuntu'
@@ -105,7 +111,9 @@ when 'suse'
   default['php']['src_deps']      = %w(libbz2-dev libc-client2007e-dev libcurl4-gnutls-dev libfreetype6-dev libgmp3-dev libjpeg62-dev libkrb5-dev libmcrypt-dev libpng12-dev libssl-dev libt1-dev)
   default['php']['fpm_user']      = 'wwwrun'
   default['php']['fpm_group']     = 'www'
-  default['php']['packages']      = %w(apache2-mod_php5 php5-pear)
+  default['php']['fpm_listen_user'] = 'wwwrun'
+  default['php']['fpm_listen_group'] = 'www'
+  default['php']['packages']         = %w(apache2-mod_php5 php5-pear)
   default['php']['mysql']['package'] = 'php5-mysql'
   lib_dir = node['kernel']['machine'] =~ /x86_64/ ? 'lib64' : 'lib'
 when 'windows'
@@ -133,7 +141,9 @@ when 'freebsd'
   default['php']['src_deps']      = %w(libbz2-dev libc-client2007e-dev libcurl4-gnutls-dev libfreetype6-dev libgmp3-dev libjpeg62-dev libkrb5-dev libmcrypt-dev libpng12-dev libssl-dev libt1-dev)
   default['php']['fpm_user']      = 'www'
   default['php']['fpm_group']     = 'www'
-  default['php']['packages']      = %w( php56 pear )
+  default['php']['fpm_listen_user'] = 'www'
+  default['php']['fpm_listen_group'] = 'www'
+  default['php']['packages']         = %w( php56 pear )
   default['php']['mysql']['package'] = 'php56-mysqli'
 else
   default['php']['conf_dir']      = '/etc/php5/cli'

--- a/providers/fpm_pool.rb
+++ b/providers/fpm_pool.rb
@@ -64,6 +64,8 @@ action :install do
       fpm_pool_user: new_resource.user,
       fpm_pool_group: new_resource.group,
       fpm_pool_listen: new_resource.listen,
+      fpm_pool_listen_user: new_resource.listen_user,
+      fpm_pool_listen_group: new_resource.listen_group,
       fpm_pool_manager: new_resource.process_manager,
       fpm_pool_max_children: new_resource.max_children,
       fpm_pool_start_servers: new_resource.start_servers,

--- a/providers/pear.rb
+++ b/providers/pear.rb
@@ -28,6 +28,8 @@ include Chef::Mixin::ShellOut
 # the Chef::Provider::Package which will make
 # refactoring into core chef easy
 
+use_inline_resources
+
 def whyrun_supported?
   true
 end
@@ -174,14 +176,14 @@ def remove_package(name, version)
 end
 
 def enable_package(name)
-  execute "/usr/sbin/php5enmod #{name}" do
-    only_if { platform?('ubuntu') && node['platform_version'].to_f >= 12.04 && ::File.exist?('/usr/sbin/php5enmod') }
+  execute "#{node['php']['enable_mod']} #{name}" do
+    only_if { platform?('ubuntu') && node['platform_version'].to_f >= 12.04 && ::File.exist?(node['php']['enable_mod']) }
   end
 end
 
 def disable_package(name)
-  execute "/usr/sbin/php5dismod #{name}" do
-    only_if { platform?('ubuntu') && node['platform_version'].to_f >= 12.04 && ::File.exist?('/usr/sbin/php5dismod') }
+  execute "#{node['php']['disable_mod']} #{name}" do
+    only_if { platform?('ubuntu') && node['platform_version'].to_f >= 12.04 && ::File.exist?(node['php']['disable_mod']) }
   end
 end
 

--- a/providers/pear_channel.rb
+++ b/providers/pear_channel.rb
@@ -35,20 +35,18 @@ end
 action :discover do
   unless exists?
     Chef::Log.info("Discovering pear channel #{@new_resource}")
-    r = execute "#{node['php']['pear']} channel-discover #{@new_resource.channel_name}" do
+    execute "#{node['php']['pear']} channel-discover #{@new_resource.channel_name}" do
       action :run
     end
-    new_resource.updated_by_last_action(true) if r.updated_by_last_action?
   end
 end
 
 action :add do
   unless exists?
     Chef::Log.info("Adding pear channel #{@new_resource} from #{@new_resource.channel_xml}")
-    r = execute "#{node['php']['pear']} channel-add #{@new_resource.channel_xml}" do
+    execute "#{node['php']['pear']} channel-add #{@new_resource.channel_xml}" do
       action :run
     end
-    new_resource.updated_by_last_action(true) if r.updated_by_last_action?
   end
 end
 
@@ -75,10 +73,9 @@ end
 action :remove do
   if exists?
     Chef::Log.info("Deleting pear channel #{@new_resource}")
-    r = execute "#{node['php']['pear']} channel-delete #{@new_resource.channel_name}" do
+    execute "#{node['php']['pear']} channel-delete #{@new_resource.channel_name}" do
       action :run
     end
-    new_resource.updated_by_last_action(true) if r.updated_by_last_action?
   end
 end
 

--- a/providers/pear_channel.rb
+++ b/providers/pear_channel.rb
@@ -26,6 +26,8 @@ require 'chef/mixin/shell_out'
 require 'chef/mixin/language'
 include Chef::Mixin::ShellOut
 
+use_inline_resources
+
 def whyrun_supported?
   true
 end
@@ -33,18 +35,20 @@ end
 action :discover do
   unless exists?
     Chef::Log.info("Discovering pear channel #{@new_resource}")
-    execute "#{node['php']['pear']} channel-discover #{@new_resource.channel_name}" do
+    r = execute "#{node['php']['pear']} channel-discover #{@new_resource.channel_name}" do
       action :run
     end
+    new_resource.updated_by_last_action(true) if r.updated_by_last_action?
   end
 end
 
 action :add do
   unless exists?
     Chef::Log.info("Adding pear channel #{@new_resource} from #{@new_resource.channel_xml}")
-    execute "#{node['php']['pear']} channel-add #{@new_resource.channel_xml}" do
+    r = execute "#{node['php']['pear']} channel-add #{@new_resource.channel_xml}" do
       action :run
     end
+    new_resource.updated_by_last_action(true) if r.updated_by_last_action?
   end
 end
 
@@ -71,9 +75,10 @@ end
 action :remove do
   if exists?
     Chef::Log.info("Deleting pear channel #{@new_resource}")
-    execute "#{node['php']['pear']} channel-delete #{@new_resource.channel_name}" do
+    r = execute "#{node['php']['pear']} channel-delete #{@new_resource.channel_name}" do
       action :run
     end
+    new_resource.updated_by_last_action(true) if r.updated_by_last_action?
   end
 end
 

--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -54,6 +54,13 @@ else
   ext_dir_prefix = ''
 end
 
+# PHP is unable to find the GMP library in 16.04. The symlink brings the file
+# inside of the include libraries.
+link '/usr/include/gmp.h' do
+  to '/usr/include/x86_64-linux-gnu/gmp.h'
+  only_if { node['platform_family'] == 'debian' && node['platform_version'].to_f >= 14.04 }
+end
+
 bash 'build php' do
   cwd Chef::Config[:file_cache_path]
   code <<-EOF

--- a/resources/fpm_pool.rb
+++ b/resources/fpm_pool.rb
@@ -24,7 +24,9 @@ actions :install, :uninstall
 attribute :pool_name, kind_of: String, name_attribute: true
 attribute :listen, default: '/var/run/php5-fpm.sock'
 attribute :user, kind_of: String, default: node['php']['fpm_user']
-attribute :group, kind_of: String, default: node['php']['fpm_user']
+attribute :group, kind_of: String, default: node['php']['fpm_group']
+attribute :listen_user, kind_of: String, default: node['php']['fpm_listen_user']
+attribute :listen_group, kind_of: String, default: node['php']['fpm_listen_group']
 attribute :process_manager, kind_of: String, default: 'dynamic'
 attribute :max_children, kind_of: Integer, default: 5
 attribute :start_servers, kind_of: Integer, default: 2

--- a/templates/default/fpm-pool.conf.erb
+++ b/templates/default/fpm-pool.conf.erb
@@ -2,8 +2,8 @@
 user = <%= @fpm_pool_user %>
 group = <%= @fpm_pool_group %>
 listen = <%= @fpm_pool_listen %>
-listen.owner = <%= @fpm_pool_user %>
-listen.group = <%= @fpm_pool_group %>
+listen.owner = <%= @fpm_pool_listen_user %>
+listen.group = <%= @fpm_pool_listen_group %>
 pm = <%= @fpm_pool_manager %>
 pm.max_children = <%= @fpm_pool_max_children %>
 pm.start_servers = <%= @fpm_pool_start_servers %>


### PR DESCRIPTION
This pull request adds support for PHP7 by moving around the order of operations for setting attributes to take into account settings in the upcoming Ubuntu 16.04, moving a few system calls into variables from the LWRP, and updating package names for php in the upcoming Ubuntu LTS 16.04. It also fixes a few foodcritic warnings.

This PR also pulls changes from #155, with updates. It creates a few extra pool configuration variables, allowing the pool listener to differ from the owner, and group to differ from the user. However, attributes have been set to mimic old behavior by default.