### PR TITLE
Refs #171 address issue where uninstall doesn't use same convention a…

### DIFF
--- a/providers/fpm_pool.rb
+++ b/providers/fpm_pool.rb
@@ -81,7 +81,7 @@ action :uninstall do
   # Ensure the FPM pacakge is installed, and the service is registered
   register_fpm_service
   # Delete the FPM pool.
-  f = file "#{node['php']['fpm_pooldir']}/#{new_resource.pool_name}" do
+  f = file "#{node['php']['fpm_pooldir']}/#{new_resource.pool_name}.conf" do
     action :delete
   end
   new_resource.updated_by_last_action(f.updated_by_last_action?)


### PR DESCRIPTION

Cookbook version

1.8

Chef-client version

Doesn't matter

Platform Details

Doesn't matter

Scenario:

:uninstall action should use the same logic as the install action in determining the file name
Currently to install a pool named foo.conf I would call
php_fpm_pool 'foo'

but to uninstall I would have to do
php_fpm_pool 'foo.conf' do
action :uninstall
end