### PR TITLE
[fix] listening correct fpm service

### DIFF
--- a/resources/fpm_pool.rb
+++ b/resources/fpm_pool.rb
@@ -22,7 +22,7 @@ default_action :install
 actions :install, :uninstall
 
 attribute :pool_name, kind_of: String, name_attribute: true
-attribute :listen, default: '/var/run/php5-fpm.sock'
+attribute :listen, default: node['php']['fpm_service']
 attribute :user, kind_of: String, default: node['php']['fpm_user']
 attribute :group, kind_of: String, default: node['php']['fpm_group']
 attribute :listen_user, kind_of: String, default: node['php']['fpm_listen_user']


### PR DESCRIPTION
### Description

PHP7 / Ubuntu 16.04 & PHP-FPM Pool Listen User/Group #169  merge request caused small bug related with listening correct php fpm service (which is configured to /var/run/php/php7.0-fpm.sock) so web server was not working properly (nginx in my case was not working with php 7 fpm)