### PR TITLE
Fix ext_conf_dir in Debian 8

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -105,6 +105,11 @@ when 'debian'
     when 10.04..12.10
       default['php']['ext_conf_dir'] = '/etc/php5/conf.d'
     end
+  when 'debian'
+    case node['platform_version'].to_i
+    when 8
+      default['php']['ext_conf_dir'] = '/etc/php5/mods-available'
+    end
   end
 when 'suse'
   default['php']['conf_dir']      = '/etc/php5/cli'


### PR DESCRIPTION
### Description

This introduces the correct ext_conf_dir for Debian 8

### Check List
- [x] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD


Debian 8 moved ext_conf_dir from /etc/php5/conf.d to the newer format Ubuntu 13.04 started using.