### PR TITLE
Fix source php version check

### DIFF
--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -39,7 +39,7 @@ remote_file "#{Chef::Config[:file_cache_path]}/php-#{version}.tar.gz" do
   source "#{node['php']['url']}/php-#{version}.tar.gz/from/this/mirror"
   checksum node['php']['checksum']
   mode '0644'
-  not_if "which #{node['php']['bin']} --version | grep #{version}"
+  not_if "$(which #{node['php']['bin']}) --version | grep #{version}"
 end
 
 if node['php']['ext_dir']
@@ -68,7 +68,7 @@ bash 'build php' do
   (cd php-#{version} && #{ext_dir_prefix} ./configure #{configure_options})
   (cd php-#{version} && make && make install)
   EOF
-  not_if "which #{node['php']['bin']} --version | grep #{version}"
+  not_if "$(which #{node['php']['bin']}) --version | grep #{version}"
 end
 
 directory node['php']['conf_dir'] do


### PR DESCRIPTION
Recipe `source` php version check is wrong and causes download and build steps to always run.
