### PR TITLE
Use all CPUs when building from source

### DIFF
--- a/recipes/recompile.rb
+++ b/recipes/recompile.rb
@@ -46,6 +46,6 @@ bash 're-build php' do
   code <<-EOF
   (make clean)
   (#{ext_dir_prefix} ./configure #{configure_options})
-  (make && make install)
+  (make -j #{node['cpu']['total']} && make install)
   EOF
 end

--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -64,7 +64,7 @@ bash 'build php' do
   code <<-EOF
   tar -zxf php-#{version}.tar.gz
   (cd php-#{version} && #{ext_dir_prefix} ./configure #{configure_options})
-  (cd php-#{version} && make && make install)
+  (cd php-#{version} && make -j #{node['cpu']['total']} && make install)
   EOF
   not_if "$(which #{node['php']['bin']}) --version | grep #{version}"
 end


### PR DESCRIPTION
Cut down time it takes to build PHP from source by number of CPUs :smile:.



