### PR TITLE
use attribute for pear_channel pear property

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ It installs and configures PHP and the PEAR package management system.  Also inc
 - Debian, Ubuntu
 - CentOS, Red Hat, Oracle, Scientific, Amazon Linux
 - Fedora
-- Microsoft Windows 
+- Microsoft Windows
 
 ### Chef
 - Chef 12.1+
@@ -23,6 +23,7 @@ It installs and configures PHP and the PEAR package management system.  Also inc
 ## Attributes
 - `node['php']['install_method']` = method to install php with, default `package`.
 - `node['php']['directives']` = Hash of directives and values to append to `php.ini`, default `{}`.
+- `node['php']['pear']` = Name of the pear executable to use, default `pear`.
 
 The file also contains the following attribute types:
 - platform specific locations and settings.

--- a/resources/pear_channel.rb
+++ b/resources/pear_channel.rb
@@ -22,7 +22,7 @@
 default_action :discover
 property :channel_xml, kind_of: String
 property :channel_name, kind_of: String, name_property: true
-property :pear, kind_of: String, default: 'pear'
+property :pear, kind_of: String, default: lazy { node['php']['pear'] }
 # TODO: add authenticated channel support!
 # property :username, :kind_of => String
 # property :password, :kind_of => String


### PR DESCRIPTION
### Description

Utilizing the `node['php']['pear']` attribute to set the `:pear` property within the `pear_channel` resource. 

### Issues Resolved

I'm using this cookbook on Amazon Linux to install PHP7. Thanks to Amazon's versioned packaging, pear7-php installs as `pear7` for use. This allows setting `node['php']['pear']` appropriately without modifying `php_pear_channel` as it is currently used in the cookbook default recipe.

### Check List

- [X] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
