### PR TITLE
Improve testing and Chef 13 compatibility

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -33,9 +33,6 @@ platforms:
       box: chef/windows-server-2012r2-standard
 
 suites:
-  - name: package_install
-    run_list:
-      - recipe[php::default]
   - name: source_install
     run_list:
       - recipe[php::default]

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -17,6 +17,11 @@ platforms:
   - name: opensuse-leap-42.2
   - name: ubuntu-14.04
   - name: ubuntu-16.04
+  - name: ubuntu-16.04-chef-12.5
+    driver_config:
+      box: bento/ubuntu-16.04
+    provisioner:
+      require_chef_omnibus: 12.5.1
   - name: freebsd-10.3
     driver:
       ssh:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -12,15 +12,11 @@ platforms:
   - name: centos-6.8
   - name: centos-7.3
   - name: debian-7.11
-    run_list: apt::default
   - name: debian-8.6
-    run_list: apt::default
   - name: fedora-25
   - name: opensuse-leap-42.2
   - name: ubuntu-14.04
-    run_list: apt::default
   - name: ubuntu-16.04
-    run_list: apt::default
   - name: freebsd-10.3
     driver:
       ssh:
@@ -33,10 +29,9 @@ platforms:
       box: chef/windows-server-2012r2-standard
 
 suites:
-  - name: source_install
-    run_list:
-      - recipe[php::default]
-    attributes: { php: { install_method: "source" } }
   - name: resource_test
     run_list:
       - recipe[test::default]
+  - name: source_install
+    run_list:
+      - recipe[test::source]

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,6 @@ services: docker
 
 env:
   matrix:
-  - INSTANCE=package-install-ubuntu-1604
-  - INSTANCE=package-install-ubuntu-1404
-  - INSTANCE=package-install-centos-7
-  - INSTANCE=package-install-centos-6
   - INSTANCE=resource-test-ubuntu-1604
   - INSTANCE=resource-test-ubuntu-1404
   - INSTANCE=resource-test-centos-7

--- a/Berksfile
+++ b/Berksfile
@@ -4,5 +4,4 @@ metadata
 
 group :integration do
   cookbook 'test', path: './test/cookbooks/test'
-  cookbook 'apt'
 end

--- a/providers/pear.rb
+++ b/providers/pear.rb
@@ -102,7 +102,7 @@ end
 # so refactoring into core Chef should be easy
 
 def load_current_resource
-  @current_resource = new_resource
+  @current_resource = new_resource.class.new(new_resource.name)
   @current_resource.package_name(@new_resource.package_name)
   @bin = node['php']['pear']
   if pecl?

--- a/providers/pear.rb
+++ b/providers/pear.rb
@@ -177,13 +177,13 @@ end
 
 def enable_package(name)
   execute "#{node['php']['enable_mod']} #{name}" do
-    only_if { platform?('ubuntu') && node['platform_version'].to_f >= 12.04 && ::File.exist?(node['php']['enable_mod']) }
+    only_if { platform?('ubuntu') && ::File.exist?(node['php']['enable_mod']) }
   end
 end
 
 def disable_package(name)
   execute "#{node['php']['disable_mod']} #{name}" do
-    only_if { platform?('ubuntu') && node['platform_version'].to_f >= 12.04 && ::File.exist?(node['php']['disable_mod']) }
+    only_if { platform?('ubuntu') && ::File.exist?(node['php']['disable_mod']) }
   end
 end
 

--- a/providers/pear.rb
+++ b/providers/pear.rb
@@ -102,7 +102,7 @@ end
 # so refactoring into core Chef should be easy
 
 def load_current_resource
-  @current_resource = Chef::Resource::PhpPear.new(@new_resource.name)
+  @current_resource = new_resource
   @current_resource.package_name(@new_resource.package_name)
   @bin = node['php']['pear']
   if pecl?

--- a/test/cookbooks/test/recipes/default.rb
+++ b/test/cookbooks/test/recipes/default.rb
@@ -6,3 +6,12 @@ include_recipe 'php'
 php_fpm_pool 'test-pool' do
   action :install
 end
+
+# add a channel
+php_pear_channel 'pear.php.net' do
+  action :update
+end
+
+# install a package from the pear.php.net channel
+# http://pear.php.net/package/HTTP2
+php_pear 'HTTP2'

--- a/test/cookbooks/test/recipes/source.rb
+++ b/test/cookbooks/test/recipes/source.rb
@@ -1,0 +1,5 @@
+apt_update 'update'
+
+node.override['php']['install_method'] = 'source'
+
+include_recipe 'php'


### PR DESCRIPTION
Move source installs to their own test recipe which removes the need for the apt cookbook
Fix php_pear failing on Chef 13
Add a test for Ubuntu 16.04 with Chef 12.5
Add php_channel and php_pear to the resources test suite
Remove the packages test suite since that's included in the resources suite