### PR TITLE
Foodcritic whitespace fix

### DIFF
--- a/providers/pear.rb
+++ b/providers/pear.rb
@@ -293,7 +293,7 @@ def pecl?
       search_args << " -d preferred_state=#{can_haz(@new_resource, 'preferred_state')}"
       search_args << " search#{expand_channel(can_haz(@new_resource, 'channel'))} #{@new_resource.package_name}"
 
-      if    grep_for_version(shell_out(node['php']['pear'] + search_args).stdout, @new_resource.package_name)
+      if grep_for_version(shell_out(node['php']['pear'] + search_args).stdout, @new_resource.package_name)
         false
       elsif grep_for_version(shell_out(node['php']['pecl'] + search_args).stdout, @new_resource.package_name)
         true


### PR DESCRIPTION
### Description

Foodcritic reports whitespace issue:
```
* position:  296:6
* property:  spaces_after_conditional
* message:   4 spaces after conditional at column 6, expected 1.
```

Obvious fix.

### Check List

- [X] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
