### PR TITLE
Fix install resource, so it doesn't install if it's already installed

### DIFF
--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -18,9 +18,6 @@ platforms:
   driver:
     image: dokken/amazonlinux
     pid_one_command: /sbin/init
-    intermediate_instructions:
-      - RUN yum -y install sudo kmod
-      - RUN cat > /etc/sysconfig/network << "EOF"
 
 - name: debian-7
   driver:

--- a/libraries/pecl_helpers.rb
+++ b/libraries/pecl_helpers.rb
@@ -33,7 +33,7 @@ module PhpCookbook
       command << " #{prefix_channel(new_resource.channel)}#{name}"
       command << "-#{version}" if version && !version.empty?
       pear_shell_out(command)
-      manage_pecl_ini(name, :create, new_resource.directives, new_resource.zend_extensions) if pecl?
+      manage_pecl_ini(name, :create, new_resource.directives, new_resource.zend_extensions, new_resource.priority) if pecl?
       enable_package(name)
     end
 
@@ -44,7 +44,7 @@ module PhpCookbook
       command << " #{prefix_channel(new_resource.channel)}#{name}"
       command << "-#{version}" if version && !version.empty?
       pear_shell_out(command)
-      manage_pecl_ini(name, :create, new_resource.directives, new_resource.zend_extensions) if pecl?
+      manage_pecl_ini(name, :create, new_resource.directives, new_resource.zend_extensions, new_resource.priority) if pecl?
       enable_package(name)
     end
 
@@ -105,7 +105,7 @@ module PhpCookbook
       files
     end
 
-    def manage_pecl_ini(name, action, directives, zend_extensions)
+    def manage_pecl_ini(name, action, directives, zend_extensions, priority)
       ext_prefix = extension_dir
       ext_prefix << ::File::SEPARATOR if ext_prefix[-1].chr != ::File::SEPARATOR
 
@@ -133,7 +133,12 @@ module PhpCookbook
         owner 'root'
         group 'root'
         mode '0644'
-        variables(name: name, extensions: extensions, directives: directives)
+        variables(
+          name: name,
+          extensions: extensions,
+          directives: directives,
+          priority: priority
+        )
         action action
       end
     end
@@ -147,12 +152,12 @@ module PhpCookbook
         # Horde_Url 1.0.0beta1 (beta) 1.0.0beta1 Horde Url class
         version = m.split(/\s+/)[1].strip
         version = if version.split(%r{/\//})[0] =~ /.\./
-              # 1.1.4/(1.1.4 stable)
-              version.split(%r{/\//})[0]
-            else
-              # -n/a-/(1.0.0beta1 beta)
-              version.split(%r{/(.*)\/\((.*)/}).last.split(/\s/)[0]
-            end
+                    # 1.1.4/(1.1.4 stable)
+                    version.split(%r{/\//})[0]
+                  else
+                    # -n/a-/(1.0.0beta1 beta)
+                    version.split(%r{/(.*)\/\((.*)/}).last.split(/\s/)[0]
+                  end
       end
       version
     end

--- a/libraries/pecl_helpers.rb
+++ b/libraries/pecl_helpers.rb
@@ -1,15 +1,13 @@
 module PhpCookbook
   module Helpers
     def current_installed_version(new_resource)
-      begin
-        version_check_cmd = "#{new_resource.binary} -d "
-        version_check_cmd << " preferred_state=#{new_resource.preferred_state}"
-        version_check_cmd << " list#{expand_channel(new_resource.channel)}"
-        p = shell_out(version_check_cmd)
-        response = nil
-        response = grep_for_version(p.stdout, new_resource.package_name) if p.stdout =~ /\.?Installed packages/i
-        response
-      end
+      version_check_cmd = "#{new_resource.binary} -d"
+      version_check_cmd << " preferred_state=#{new_resource.preferred_state}"
+      version_check_cmd << " list#{expand_channel(new_resource.channel)}"
+      p = shell_out(version_check_cmd)
+      response = nil
+      response = grep_for_version(p.stdout, new_resource.package_name) if p.stdout =~ /\.?Installed packages/i
+      response
     end
 
     def expand_options(options)
@@ -17,16 +15,14 @@ module PhpCookbook
     end
 
     def candidate_version
-      begin
-        candidate_version_cmd = "#{new_resource.binary} -d "
-        candidate_version_cmd << "preferred_state=#{new_resource.preferred_state}"
-        candidate_version_cmd << " search#{expand_channel(new_resource.channel)}"
-        candidate_version_cmd << " #{new_resource.package_name}"
-        p = shell_out(candidate_version_cmd)
-        response = nil
-        response = grep_for_version(p.stdout, new_resource.package_name) if p.stdout =~ /\.?Matched packages/i
-        response
-      end
+      candidate_version_cmd = "#{new_resource.binary} -d "
+      candidate_version_cmd << "preferred_state=#{new_resource.preferred_state}"
+      candidate_version_cmd << " search#{expand_channel(new_resource.channel)}"
+      candidate_version_cmd << " #{new_resource.package_name}"
+      p = shell_out(candidate_version_cmd)
+      response = nil
+      response = grep_for_version(p.stdout, new_resource.package_name) if p.stdout =~ /\.?Matched packages/i
+      response
     end
 
     def install_package(name, version, **opts)
@@ -143,23 +139,22 @@ module PhpCookbook
     end
 
     def grep_for_version(stdout, package)
-      v = nil
-
+      version = nil
       stdout.split(/\n/).grep(/^#{package}\s/i).each do |m|
         # XML_RPC          1.5.4    stable
         # mongo   1.1.4/(1.1.4 stable) 1.1.4 MongoDB database driver
         # Horde_Url -n/a-/(1.0.0beta1 beta)       Horde Url class
         # Horde_Url 1.0.0beta1 (beta) 1.0.0beta1 Horde Url class
-        v = m.split(/\s+/)[1].strip
-        v = if v.split(%r{/\//})[0] =~ /.\./
+        version = m.split(/\s+/)[1].strip
+        version = if version.split(%r{/\//})[0] =~ /.\./
               # 1.1.4/(1.1.4 stable)
-              v.split(%r{/\//})[0]
+              version.split(%r{/\//})[0]
             else
               # -n/a-/(1.0.0beta1 beta)
-              v.split(%r{/(.*)\/\((.*)/}).last.split(/\s/)[0]
+              version.split(%r{/(.*)\/\((.*)/}).last.split(/\s/)[0]
             end
       end
-      v
+      version
     end
 
     def pecl?

--- a/resources/pear.rb
+++ b/resources/pear.rb
@@ -31,23 +31,25 @@ include PhpCookbook::Helpers
 
 load_current_value do |new_resource|
   unless current_installed_version(new_resource).nil?
-      version(current_installed_version(new_resource))
-      Chef::Log.debug("Current version is #{version}") if version
+    version(current_installed_version(new_resource))
+    Chef::Log.debug("Current version is #{version}") if version
   end
 end
 
 action :install do
   # If we specified a version, and it's not the current version, move to the specified version
   install_version = new_resource.version unless new_resource.version.nil? || new_resource.version == current_resource.version
+  # Check if the version we want is already installed
+  versions_match = candidate_version == current_installed_version(new_resource)
 
   # If it's not installed at all or an upgrade, install it
-  if install_version || new_resource.version.nil?
-    description = "install package #{new_resource.package_name} #{install_version}"
-    converge_by(description) do
+  if install_version || new_resource.version.nil? && !versions_match
+    converge_by("install package #{new_resource.package_name} #{install_version}") do
       info_output = "Installing #{new_resource.package_name}"
       info_output << " version #{install_version}" if install_version && !install_version.empty?
       Chef::Log.info(info_output)
       install_package(new_resource.package_name, install_version)
+      not_if { candidate_version == current_installed_version(new_resource) }
     end
   end
 end
@@ -55,8 +57,7 @@ end
 # reinstall is just an install that always fires
 action :reinstall do
   install_version = new_resource.version unless new_resource.version.nil?
-  description = "reinstall package #{new_resource.package_name} #{install_version}"
-  converge_by(description) do
+  converge_by("reinstall package #{new_resource.package_name} #{install_version}") do
     info_output = "Installing #{new_resource.package_name}"
     info_output << " version #{install_version}" if install_version && !install_version.empty?
     Chef::Log.info(info_output)
@@ -76,8 +77,7 @@ end
 
 action :remove do
   if removing_package?
-    description = "remove package #{new_resource.package_name}"
-    converge_by(description) do
+    converge_by("remove package #{new_resource.package_name}") do
       remove_package(@current_resource.package_name, new_resource.version)
     end
   end
@@ -85,8 +85,7 @@ end
 
 action :purge do
   if removing_package?
-    description = "purge package #{new_resource.package_name}"
-    converge_by(description) do
+    converge_by("purge package #{new_resource.package_name}") do
       remove_package(@current_resource.package_name, new_resource.version)
     end
   end

--- a/resources/pear.rb
+++ b/resources/pear.rb
@@ -26,6 +26,7 @@ property :directives, Hash, default: {}
 property :zend_extensions, Array, default: []
 property :preferred_state, String, default: 'stable'
 property :binary, String, default: 'pear'
+property :priority, [String, nil], default: nil
 
 include PhpCookbook::Helpers
 

--- a/test/cookbooks/test/recipes/default.rb
+++ b/test/cookbooks/test/recipes/default.rb
@@ -2,18 +2,19 @@ apt_update 'update'
 
 include_recipe 'php'
 
-# create a test pool
+# Create a test pool
 php_fpm_pool 'test-pool' do
   action :install
 end
 
-# add a channel
+# Add a channel
 php_pear_channel 'pear.php.net' do
   action :update
 end
 
-# install a package from the pear.php.net channel
+# Install a package from the pear.php.net channel
 # http://pear.php.net/package/HTTP2
+php_pear 'HTTP2'
 php_pear 'HTTP2'
 
 php_pear 'Remove it now' do


### PR DESCRIPTION
- Remove unused being blocks, as we never raise anything in them.
- Load in the current value of the installed package so we don't try to
install a  package we've already got installed.
- Update tests to install HTTP2 twice

### Description

[Describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
