### PR TITLE
Don't eval the action_class

### DIFF
--- a/resources/pear.rb
+++ b/resources/pear.rb
@@ -92,6 +92,6 @@ action :purge do
   end
 end
 
-action_class.class_eval do
+action_class do
   include PhpCookbook::Helpers
 end


### PR DESCRIPTION
No need to do this with 12.7+

Signed-off-by: Tim Smith <tsmith@chef.io>