### PR TITLE
use php pear binary property in all recipes

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -23,10 +23,12 @@ include_recipe "php::#{node['php']['install_method']}"
 
 # update the main channels
 php_pear_channel 'pear.php.net' do
+  binary node['php']['pear']
   action :update
 end
 
 php_pear_channel 'pecl.php.net' do
+  binary node['php']['pear']
   action :update
 end
 

--- a/recipes/module_apc.rb
+++ b/recipes/module_apc.rb
@@ -24,6 +24,7 @@ when 'rhel', 'fedora', 'amazon'
   package %w(httpd-devel pcre pcre-devel)
 
   php_pear 'APC' do
+    binary node['php']['pear']
     action :install
     directives(shm_size: '128M', enable_cli: 0)
   end

--- a/recipes/module_apcu.rb
+++ b/recipes/module_apcu.rb
@@ -24,6 +24,7 @@ when 'rhel', 'fedora', 'amazon'
   package %w(httpd-devel pcre pcre-devel)
 
   php_pear 'APCu' do
+    binary node['php']['pear']
     action :install
     directives(shm_size: '128M', enable_cli: 0)
   end

--- a/recipes/module_fpdf.rb
+++ b/recipes/module_fpdf.rb
@@ -22,10 +22,12 @@
 case node['platform_family']
 when 'rhel', 'fedora', 'amazon'
   pearhub_chan = php_pear_channel 'pearhub.org' do
+    binary node['php']['pear']
     action :discover
   end
   php_pear 'FPDF' do
     channel pearhub_chan.channel_name
+    binary node['php']['pear']
     action :install
   end
 when 'debian'

--- a/recipes/module_memcache.rb
+++ b/recipes/module_memcache.rb
@@ -24,6 +24,7 @@ when 'rhel', 'fedora', 'amazon'
   package 'zlib-devel'
 
   php_pear 'memcache' do
+    binary node['php']['pear']
     action :install
   end
 when 'debian'


### PR DESCRIPTION
### Description

This commit adds the usage of the `binary` property to all uses of the
`php_pear` and `php_pear_channel` resources in the cookbook. This allows
users of the cookbook to override the pear binary location when using
these recipes.

### Issues Resolved

#228
