### PR TITLE
Allow default recipe to skip pear channel configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ It installs and configures PHP and the PEAR package management system. Also incl
 
 - `node['php']['install_method']` = method to install php with, default `package`.
 - `node['php']['directives']` = Hash of directives and values to append to `php.ini`, default `{}`.
+- `node['php']['pear_setup']` = Boolean value to determine whether to set up pear repositories. Default: `true`
+- `node['php']['pear_channels']` = List of external pear channels to add if `node['php']['pear_setup]` is true. Default: `['pear.php.net', 'pecl.php.net']`
 
 The file also contains the following attribute types:
 
@@ -244,6 +246,7 @@ This cookbook is maintained by Chef's Community Cookbook Engineering team. Our g
 ## License
 
 **Copyright:** 2011-2018, Chef Software, Inc.
+**Copyright:** 2018, Oracle and/or its affiliates. All rights reserved
 
 ```
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -30,7 +30,7 @@ default['php']['pear'] = '/usr/bin/pear'
 default['php']['pear_setup'] = true
 default['php']['pear_channels'] = [
   'pear.php.net',
-  'pecl.php.net'
+  'pecl.php.net',
 ]
 
 default['php']['url'] = 'http://us1.php.net/get'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -27,6 +27,11 @@ default['php']['pecl'] = 'pecl'
 default['php']['version'] = '5.6.30'
 
 default['php']['pear'] = '/usr/bin/pear'
+default['php']['pear_setup'] = true
+default['php']['pear_channels'] = [
+  'pear.php.net',
+  'pecl.php.net'
+]
 
 default['php']['url'] = 'http://us1.php.net/get'
 default['php']['checksum'] = '8bc7d93e4c840df11e3d9855dcad15c1b7134e8acf0cf3b90b932baea2d0bde2'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -22,14 +22,12 @@
 include_recipe "php::#{node['php']['install_method']}"
 
 # update the main channels
-php_pear_channel 'pear.php.net' do
-  binary node['php']['pear']
-  action :update
-end
-
-php_pear_channel 'pecl.php.net' do
-  binary node['php']['pear']
-  action :update
+node['php']['pear_channels'].each do |channel|
+  php_pear_channel channel do
+    binary node['php']['pear']
+    action :update
+    only_if { node['php']['pear_setup'] }
+  end
 end
 
 include_recipe 'php::ini'


### PR DESCRIPTION
Signed-off-by: Matt Clyde <matt.clyde@oracle.com>

### Description

Allow pear channel setup to be disabled in the default recipe using a boolean attribute. Stays enabled by default.

### Issues Resolved 

#233 

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
