### PR TITLE
Pass in missing argument to manage_pecl_ini method when trying to rem…

### DIFF
--- a/resources/pear.rb
+++ b/resources/pear.rb
@@ -168,7 +168,7 @@ action_class do
     command << "-#{version}" if version && !version.empty?
     pear_shell_out(command)
     disable_package(name)
-    manage_pecl_ini(name, :delete, nil, nil) if pecl?
+    manage_pecl_ini(name, :delete, nil, nil, nil) if pecl?
   end
 
   def enable_package(name)


### PR DESCRIPTION
When trying to call 'action :remove' on a pecl module, it would fail with 'expected 5 arguments, only 4 provided', this is due to the missing priority argument in the method call